### PR TITLE
Enable manual input & adjust subdirectory picker

### DIFF
--- a/directorypicker.py
+++ b/directorypicker.py
@@ -9,7 +9,12 @@ def st_directory_picker(initial_path=Path()):
     if "path" not in st.session_state:
         st.session_state.path = initial_path.absolute()
 
-    st.text_input("Selected directory:", st.session_state.path)
+    manual_input = st.text_input("Selected directory:", st.session_state.path)
+
+    manual_input = Path(manual_input)
+    if manual_input != st.session_state.path:
+        st.session_state.path = manual_input
+        st.experimental_rerun()
 
     _, col1, col2, col3, _ = st.columns([3, 1, 3, 1, 3])
 


### PR DESCRIPTION
Love this small project!

Noticed that you could only navigate with the subdirectory arrows, but not copypaste or change the text_input field, as the field is only used as a "path" display field and also the subdirectory menu would not reset proberly.

With this PR you can use both the subdirectories navigation and the text_input field and it reset the subdirectory menu. Tested it quite a bit and seems to work well!